### PR TITLE
Pouvoir afficher un logo au format SVG dans une liste d'objet

### DIFF
--- a/css/logo_svg_prive.css
+++ b/css/logo_svg_prive.css
@@ -1,0 +1,5 @@
+/* Surcharge de https://core.spip.net/projects/spip/repository/entry/spip/prive/themes/spip/lists.css.html */
+/* Permet, dans tout les cas, d'afficher un logo au format SVG dans une liste d'objet de l'espace privé, comme par exemple dans ecrire/?exec=articles */
+.liste-objets tr td.logo {
+	min-width:40px;
+}

--- a/paquet.xml
+++ b/paquet.xml
@@ -16,5 +16,6 @@
 	<licence>GNU/GPL</licence>
 
 	<necessite nom="medias" compatibilite="[2.10.28;]" />
+	<style source="css/logo_svg_prive.css" type="prive" />
 
 </paquet>


### PR DESCRIPTION
Dans les listes d'objets (articles, mot-clés, etc.) de l'espace privé,  on ajoute un `min-width:40px` sur la bloc qui affiche le logo si présent. Ainsi on créé de la place les images SVG qui n'ont pas de taille.